### PR TITLE
Log engine name and duration when search thread times out

### DIFF
--- a/src/searx/search/__init__.py
+++ b/src/searx/search/__init__.py
@@ -158,7 +158,9 @@ class Search:
                 if th.is_alive():
                     th._timeout = True
                     self.result_container.add_unresponsive_engine(th._engine_name, 'timeout')
-                    PROCESSORS[th._engine_name].logger.error('engine timeout')
+                    PROCESSORS[th._engine_name].logger.error(
+                        "engine %s timeout after %.2fs", th._engine_name, self.actual_timeout
+                    )
 
     def search_standard(self):
         """


### PR DESCRIPTION
## Summary
- log engine name and timeout duration when a search request thread exceeds timeout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a34b3a26f48328a384c710b087b650