### PR TITLE
Expose unresponsive search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ az functionapp keys list \
 Notes:
 - The `websearch` endpoint expects a `query` field. Do not send OpenAI-style payloads like `{ "prompt": ... }`.
 - `ping` is anonymous; `websearch` uses `FUNCTION` auth by default.
+- Responses from `/api/websearch` include an `unresponsive_engines` array with
+  engine names and error types for any engines that failed to respond.
 
 ## Connect to the *local* MCP server from a client/host (optional)
 
@@ -392,6 +394,8 @@ az functionapp keys list \
 Notes:
 - The `websearch` endpoint expects a `query` field. Do not send OpenAI-style payloads like `{ "prompt": ... }`.
 - `ping` is anonymous; `websearch` uses `FUNCTION` auth by default.
+- Responses from `/api/websearch` include an `unresponsive_engines` array with
+  engine names and error types for any engines that failed to respond.
 
 ## Source Code (snippets)
 

--- a/src/websearch/service.py
+++ b/src/websearch/service.py
@@ -78,7 +78,11 @@ def perform_search(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Run a search using SearXNG core based on the given payload.
 
     Expected payload keys: query (str), engines (list[str]|str), language (str),
-    time_range (str), pageno (int), safesearch (int), max_results (int)
+    time_range (str), pageno (int), safesearch (int), max_results (int).
+
+    The returned dictionary includes an ``unresponsive_engines`` field listing
+    engines that failed to respond. Each entry contains the engine name and the
+    error type encountered.
     """
     _initialize_search_core()
 
@@ -127,6 +131,10 @@ def perform_search(payload: Dict[str, Any]) -> Dict[str, Any]:
         "paging": result_container.paging,
         "number_of_results": result_container.number_of_results,
     }
+    response["unresponsive_engines"] = [
+        {"engine": u.engine, "error": u.error_type}
+        for u in result_container.unresponsive_engines
+    ]
     return response
 
 


### PR DESCRIPTION
## Summary
- include list of unresponsive engines in perform_search response
- document unresponsive_engines in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34c8325a88328b7c17b7c363a003c